### PR TITLE
vm: move error into `Vm` to speed up `threaded` interpreter a bit

### DIFF
--- a/crabbing-interpreters/src/bytecode.rs
+++ b/crabbing-interpreters/src/bytecode.rs
@@ -111,7 +111,7 @@ impl Index<usize> for CompiledBytecodes<'_> {
     }
 }
 
-type CompiledBytecode = for<'a> fn(&mut Vm<'a, '_>, CompiledBytecodes);
+type CompiledBytecode = fn(&mut Vm, CompiledBytecodes);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct CallInner {

--- a/crabbing-interpreters/src/bytecode/vm.rs
+++ b/crabbing-interpreters/src/bytecode/vm.rs
@@ -115,6 +115,7 @@ pub(crate) struct Vm<'a, 'b> {
     call_stack: Stack<CallFrame<'a>>,
     cell_vars: Cells<'a>,
     execution_counts: Box<[u64; Bytecode::all_discriminants().len()]>,
+    error: Option<Box<Error<'a>>>,
 }
 
 impl<'a, 'b> Vm<'a, 'b> {
@@ -144,6 +145,7 @@ impl<'a, 'b> Vm<'a, 'b> {
             }),
             cell_vars: global_cells,
             execution_counts: Box::new([0; Bytecode::all_discriminants().len()]),
+            error: None,
         })
     }
 
@@ -155,6 +157,14 @@ impl<'a, 'b> Vm<'a, 'b> {
 
     pub(crate) fn pc(&self) -> usize {
         self.pc
+    }
+
+    pub(crate) fn set_error(&mut self, error: Option<Box<Error<'a>>>) {
+        self.error = error;
+    }
+
+    pub(crate) fn error(self) -> Option<Box<Error<'a>>> {
+        self.error
     }
 
     pub(crate) fn execution_counts(&self) -> &[u64; Bytecode::all_discriminants().len()] {

--- a/crabbing-interpreters/src/lib.rs
+++ b/crabbing-interpreters/src/lib.rs
@@ -432,8 +432,7 @@ pub fn run<'a>(
                             stack,
                             global_cells,
                         )?;
-                        let mut error = None;
-                        compiled_bytecodes[vm.pc()](&mut vm, compiled_bytecodes, &mut error);
+                        compiled_bytecodes[vm.pc()](&mut vm, compiled_bytecodes);
 
                         if args.show_bytecode_execution_counts {
                             let max_len = Bytecode::all_discriminants()
@@ -451,7 +450,7 @@ pub fn run<'a>(
                             }
                         }
 
-                        match error {
+                        match vm.error() {
                             Some(error) => Err(error)?,
                             None => Value::Nil,
                         }


### PR DESCRIPTION
This avoids a parameter for compiled bytecode functions, reducing register pressure.