### PR TITLE
vm: make `CompiledBytecodes` smaller

### DIFF
--- a/crabbing-interpreters/src/bytecode/vm.rs
+++ b/crabbing-interpreters/src/bytecode/vm.rs
@@ -621,7 +621,9 @@ pub(crate) fn execute_bytecode<'a>(
             unsafe { nanboxed::Value::from_f64_unchecked(number.into()) },
         ),
     }
-    vm.pc += 1;
+    unsafe {
+        vm.pc = vm.pc.unchecked_add(1);
+    }
     if cfg!(miri) || previous_pc > vm.pc {
         vm.collect_if_necessary();
     }

--- a/crabbing-interpreters/src/lib.rs
+++ b/crabbing-interpreters/src/lib.rs
@@ -367,7 +367,7 @@ pub fn run<'a>(
                 .map(|bytecode| bytecode.compile())
                 .collect_vec()
         });
-        let compiled_bytecodes = CompiledBytecodes(&compiled_bytecodes);
+        let compiled_bytecodes = CompiledBytecodes::new(&compiled_bytecodes);
 
         if args.bytecode {
             println!("Interned strings");
@@ -432,7 +432,8 @@ pub fn run<'a>(
                             stack,
                             global_cells,
                         )?;
-                        let compiled_bytecode = compiled_bytecodes[vm.pc()];
+                        let compiled_bytecode =
+                            unsafe { compiled_bytecodes.get_unchecked(vm.pc()) };
                         (compiled_bytecode.function)(&mut vm, compiled_bytecodes);
 
                         if args.show_bytecode_execution_counts {


### PR DESCRIPTION
This reduces register pressure in the `threaded` interpreter.