### PR TITLE
vm: use `"rust-cold"` calling convention for slow paths

### DIFF
--- a/crabbing-interpreters/src/lib.rs
+++ b/crabbing-interpreters/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(macro_metavar_expr)]
 #![feature(never_type)]
 #![feature(ptr_metadata)]
+#![feature(rust_cold_cc)]
 #![feature(slice_from_ptr_range)]
 #![feature(slice_ptr_get)]
 #![feature(stmt_expr_attributes)]


### PR DESCRIPTION
This reduces register pressure in the fast path because the callee saves more registers.