### PR TITLE
vm: Implement `LoadMethod` optimisation

### DIFF
--- a/crabbing-interpreters/src/bytecode/compiler.rs
+++ b/crabbing-interpreters/src/bytecode/compiler.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use variant_types::IntoVariant as _;
+
 use crate::bytecode::vm::stack::Stack;
 use crate::bytecode::Bytecode;
 use crate::bytecode::Bytecode::*;
@@ -13,6 +15,7 @@ use crate::parse::LiteralKind;
 use crate::parse::UnaryOpKind;
 use crate::scope::AssignmentTarget;
 use crate::scope::Expression;
+use crate::scope::ExpressionTypes;
 use crate::scope::Function;
 use crate::scope::Statement;
 use crate::scope::Target;
@@ -349,57 +352,17 @@ impl<'a> Compiler<'a> {
                     }
                 }
             }
-            Expression::Call {
-                callee,
-                l_paren: _,
-                arguments,
-                r_paren: _,
-                stack_size_at_callsite,
-            } => match callee {
+            Expression::Call { callee, .. } => match callee {
                 Expression::Attribute { lhs, attribute } => {
                     self.enter_expression(self.code.len(), callee);
                     self.compile_expr(lhs);
                     self.code.push(LoadMethod(attribute.id()));
                     self.exit_expression(self.code.len());
-                    for arg in *arguments {
-                        self.compile_expr(arg);
-                    }
-                    let argument_count = arguments.len().try_into().unwrap();
-                    let inner = CallInner {
-                        argument_count,
-                        stack_size_at_callsite: u32::try_from(*stack_size_at_callsite).unwrap(),
-                    };
-                    let call = if usize::try_from(argument_count).unwrap()
-                        >= (Stack::<nanboxed::Value>::ELEMENT_COUNT_IN_GUARD_AREA - 2)
-                    {
-                        CallMethod(inner)
-                    }
-                    else {
-                        ShortCallMethod(inner)
-                    };
-                    self.code.push(call);
-                    self.code.push(Pop23);
+                    self.compile_call(&expr.into_variant(), 2, CallMethod, ShortCallMethod, Pop23);
                 }
                 _ => {
                     self.compile_expr(callee);
-                    for arg in *arguments {
-                        self.compile_expr(arg);
-                    }
-                    let argument_count = arguments.len().try_into().unwrap();
-                    let inner = CallInner {
-                        argument_count,
-                        stack_size_at_callsite: u32::try_from(*stack_size_at_callsite).unwrap(),
-                    };
-                    let call = if usize::try_from(argument_count).unwrap()
-                        >= (Stack::<nanboxed::Value>::ELEMENT_COUNT_IN_GUARD_AREA - 1)
-                    {
-                        Call(inner)
-                    }
-                    else {
-                        ShortCall(inner)
-                    };
-                    self.code.push(call);
-                    self.code.push(Pop2);
+                    self.compile_call(&expr.into_variant(), 1, Call, ShortCall, Pop2);
                 }
             },
             Expression::Attribute { lhs, attribute } => {
@@ -475,6 +438,34 @@ impl<'a> Compiler<'a> {
             .push(Metadata::Function { function, code_size });
         self.code
             .push(BuildFunction(meta_index.try_into().unwrap()));
+    }
+
+    fn compile_call(
+        &mut self,
+        call: &ExpressionTypes::Call<'a>,
+        stack_slot_count_occupied_by_callee: usize,
+        long_call: impl FnOnce(CallInner) -> Bytecode,
+        short_call: impl FnOnce(CallInner) -> Bytecode,
+        pop: Bytecode,
+    ) {
+        for arg in call.arguments {
+            self.compile_expr(arg);
+        }
+        let inner = CallInner {
+            argument_count: u32::try_from(call.arguments.len()).unwrap(),
+            stack_size_at_callsite: u32::try_from(call.stack_size_at_callsite).unwrap(),
+        };
+        let max_argument_count_for_short_call =
+            Stack::<nanboxed::Value>::ELEMENT_COUNT_IN_GUARD_AREA
+                - stack_slot_count_occupied_by_callee;
+        let call = if call.arguments.len() >= max_argument_count_for_short_call {
+            long_call(inner)
+        }
+        else {
+            short_call(inner)
+        };
+        self.code.push(call);
+        self.code.push(pop);
     }
 
     fn enter_expression(&mut self, at: usize, expr: &'a Expression<'a>) {

--- a/crabbing-interpreters/src/bytecode/compiler.rs
+++ b/crabbing-interpreters/src/bytecode/compiler.rs
@@ -370,7 +370,7 @@ impl<'a> Compiler<'a> {
                         stack_size_at_callsite: u32::try_from(*stack_size_at_callsite).unwrap(),
                     };
                     let call = if usize::try_from(argument_count).unwrap()
-                        >= (Stack::<nanboxed::Value>::ELEMENT_COUNT_IN_GUARD_AREA - 1)
+                        >= (Stack::<nanboxed::Value>::ELEMENT_COUNT_IN_GUARD_AREA - 2)
                     {
                         CallMethod(inner)
                     }

--- a/crabbing-interpreters/src/bytecode/vm.rs
+++ b/crabbing-interpreters/src/bytecode/vm.rs
@@ -1092,7 +1092,7 @@ fn execute_call_method<'a>(
             let result = vm.stack_mut(sp).swap(argument_count, argument_count + 1);
             result.unwrap();
         }
-        execute_call(vm, pc, sp, argument_count, stack_size_at_callsite, peeker)?
+        execute_call(vm, pc, sp, argument_count, stack_size_at_callsite, peeker)
     }
     else {
         match callee {
@@ -1133,9 +1133,8 @@ fn execute_call_method<'a>(
             }
             _ => unreachable!("classes can only contain functions"),
         }
+        Ok(())
     }
-
-    Ok(())
 }
 
 mod stack_ref {

--- a/crabbing-interpreters/src/bytecode/vm.rs
+++ b/crabbing-interpreters/src/bytecode/vm.rs
@@ -1100,6 +1100,7 @@ fn execute_call_method<'a>(
     }
 }
 
+#[inline(always)]
 fn execute_function_call<'a>(
     vm: &mut Vm<'a, '_>,
     pc: &mut usize,

--- a/crabbing-interpreters/src/bytecode/vm.rs
+++ b/crabbing-interpreters/src/bytecode/vm.rs
@@ -727,7 +727,7 @@ pub(crate) fn execute_bytecode<'a>(
             vm.print_stack(*pc, *sp);
         }
         b @ BoundMethodGetInstance => {
-            let value = vm.stack_mut(sp).peek();
+            let value = vm.stack(*sp).peek();
             match value.parse() {
                 BoundMethod(bound_method) => vm
                     .stack_mut(sp)

--- a/crabbing-interpreters/src/bytecode/vm.rs
+++ b/crabbing-interpreters/src/bytecode/vm.rs
@@ -1089,7 +1089,8 @@ fn execute_call_method<'a>(
 
     if instance.parse() == Value::Nil {
         unsafe {
-            vm.stack_mut(sp).swap(argument_count, argument_count + 1);
+            let result = vm.stack_mut(sp).swap(argument_count, argument_count + 1);
+            result.unwrap();
         }
         execute_call(vm, pc, sp, argument_count, stack_size_at_callsite, peeker)?
     }
@@ -1158,7 +1159,7 @@ mod stack_ref {
             Self { sp, stack }
         }
 
-        pub(super) unsafe fn swap(&mut self, i: u32, j: u32) {
+        pub(super) unsafe fn swap(&mut self, i: u32, j: u32) -> Result<(), ()> {
             unsafe { self.stack.swap(i, j) }
         }
     }

--- a/crabbing-interpreters/src/bytecode/vm/mmap_stack.rs
+++ b/crabbing-interpreters/src/bytecode/vm/mmap_stack.rs
@@ -121,7 +121,7 @@ where
 }
 
 impl<T> Stack<T> {
-    pub(super) unsafe fn swap(&mut self, i: u32, j: u32) {
+    pub(super) unsafe fn swap(&mut self, i: u32, j: u32) -> Result<(), ()> {
         debug_assert_ne!(i, j);
         let i_offset = peek_offset(i);
         let j_offset = peek_offset(j);
@@ -133,6 +133,7 @@ impl<T> Stack<T> {
                 self.pointer.offset(j_offset).as_mut(),
             );
         }
+        Ok(())
     }
 
     pub(super) fn peek_at_mut(&mut self, index: u32) -> &mut T {

--- a/crabbing-interpreters/src/bytecode/vm/mmap_stack.rs
+++ b/crabbing-interpreters/src/bytecode/vm/mmap_stack.rs
@@ -121,6 +121,20 @@ where
 }
 
 impl<T> Stack<T> {
+    pub(super) unsafe fn swap(&mut self, i: u32, j: u32) {
+        debug_assert_ne!(i, j);
+        let i_offset = peek_offset(i);
+        let j_offset = peek_offset(j);
+        debug_assert!(self.is_in_bounds(i_offset));
+        debug_assert!(self.is_in_bounds(j_offset));
+        unsafe {
+            std::mem::swap(
+                self.pointer.offset(i_offset).as_mut(),
+                self.pointer.offset(j_offset).as_mut(),
+            );
+        }
+    }
+
     pub(super) fn peek_at_mut(&mut self, index: u32) -> &mut T {
         let offset = peek_offset(index);
         assert!(self.is_in_bounds(offset));

--- a/crabbing-interpreters/src/bytecode/vm/stack.rs
+++ b/crabbing-interpreters/src/bytecode/vm/stack.rs
@@ -29,6 +29,13 @@ impl<T> Stack<T> {
             pointer,
         }
     }
+
+    pub(super) unsafe fn swap(&mut self, i: u32, j: u32) {
+        self.stack.swap(
+            self.pointer - 1 - usize::try_from(i).unwrap(),
+            self.pointer - 1 - usize::try_from(j).unwrap(),
+        );
+    }
 }
 
 impl<T> Stack<T>

--- a/crabbing-interpreters/src/lib.rs
+++ b/crabbing-interpreters/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(closure_lifetime_binder)]
 #![feature(closure_track_caller)]
 #![feature(debug_closure_helpers)]
+#![feature(get_many_mut)]
 #![feature(integer_sign_cast)]
 #![feature(lint_reasons)]
 #![feature(macro_metavar_expr)]

--- a/crabbing-interpreters/tests/testsuite/snapshots/testsuite__that_threaded_interpreter_is_properly_tailrecursive.snap
+++ b/crabbing-interpreters/tests/testsuite/snapshots/testsuite__that_threaded_interpreter_is_properly_tailrecursive.snap
@@ -38,32 +38,36 @@ Bytecode execution counts
                   Cell (17):      6000001
                    Dup (18):      5000000
              StoreAttr (19):      1000000
-              LoadAttr (20):      3000000
-            StoreLocal (21):      9000001
-           StoreGlobal (22):      1000003
-             StoreCell (23):      1000000
-            DefineCell (24):      1000001
-                  Call (25):            0
-             ShortCall (26):      8000000
-                 Print (27):      1000000
-          GlobalByName (28):      1000000
-     StoreGlobalByName (29):      1000000
-            JumpIfTrue (30):      3000002
-           JumpIfFalse (31):      2000000
-         PopJumpIfTrue (32):      1000000
-        PopJumpIfFalse (33):      2000000
-                  Jump (34):      1000002
-         BeginFunction (35):      3000002
-                Return (36):      5000000
-         BuildFunction (37):      3000002
-                   End (38):            1
-                  Pop2 (39):      8000000
-            BuildClass (40):      2000000
-            PrintStack (41):            0
-BoundMethodGetInstance (42):      3000000
-                 Super (43):      1000000
-              ConstNil (44):      7000000
-             ConstTrue (45):      2000000
-            ConstFalse (46):      3000000
-           ConstNumber (47):     29000005
+              LoadAttr (20):      1000000
+            LoadMethod (21):      2000000
+            StoreLocal (22):      9000001
+           StoreGlobal (23):      1000003
+             StoreCell (24):      1000000
+            DefineCell (25):      1000001
+                  Call (26):            0
+             ShortCall (27):      6000000
+            CallMethod (28):            0
+       ShortCallMethod (29):      2000000
+                 Print (30):      1000000
+          GlobalByName (31):      1000000
+     StoreGlobalByName (32):      1000000
+            JumpIfTrue (33):      3000002
+           JumpIfFalse (34):      2000000
+         PopJumpIfTrue (35):      1000000
+        PopJumpIfFalse (36):      2000000
+                  Jump (37):      1000002
+         BeginFunction (38):      3000002
+                Return (39):      5000000
+         BuildFunction (40):      3000002
+                   End (41):            1
+                  Pop2 (42):      6000000
+                 Pop23 (43):      2000000
+            BuildClass (44):      2000000
+            PrintStack (45):            0
+BoundMethodGetInstance (46):      3000000
+                 Super (47):      1000000
+              ConstNil (48):      7000000
+             ConstTrue (49):      2000000
+            ConstFalse (50):      3000000
+           ConstNumber (51):     29000005
                  Total     :    184000023


### PR DESCRIPTION
With this optimisation we avoid allocating `BoundMethod` objects for every method lookup: Expressions of the form `(call (attr ...))` are special-cased to compile to a combination of `LoadMethod` and `CallMethod` opcodes, where `LoadMethod` pushes the instance and the method separately onto the stack (instead of contained in a single allocated `BoundMethod` object).

See https://doc.pypy.org/en/latest/interpreter-optimizations.html#lookup-method-call-method