### PR TITLE
vm: Pass the program counter as a pointer

### DIFF
--- a/crabbing-interpreters/src/bytecode.rs
+++ b/crabbing-interpreters/src/bytecode.rs
@@ -66,7 +66,7 @@ macro_rules! bytecode {
                             #[allow(non_snake_case)]
                             fn $variant_name<'a>(
                                 vm: &mut Vm<'a, '_>,
-                                mut pc: usize,
+                                mut pc: NonNull<CompiledBytecode>,
                                 mut sp: NonNull<nanboxed::Value<'a>>,
                                 mut offset: u32,
                                 compiled_program: CompiledBytecodes,
@@ -74,7 +74,7 @@ macro_rules! bytecode {
                                 let $name::$variant_name $( ( $( $variant_name ${ignore($ty)} ,)* ) )?
                                     // SAFETY: `compiled_program` has the same length as
                                     // `vm.bytecode` and `vm.pc()` is always in bounds for that
-                                    = unsafe { compiled_program.get_unchecked(pc) }.bytecode
+                                    = unsafe { pc.read() }.bytecode
                                 else {
                                     unsafe {
                                         std::hint::unreachable_unchecked();
@@ -85,7 +85,8 @@ macro_rules! bytecode {
                                     &mut pc,
                                     &mut sp,
                                     &mut offset,
-                                    $name::$variant_name $( ( $( $variant_name ${ignore($ty)} ,)* ) )?
+                                    compiled_program,
+                                    $name::$variant_name $( ( $( $variant_name ${ignore($ty)} ,)* ) )?,
                                 );
                                 match result {
                                     Err(value) => {
@@ -97,7 +98,7 @@ macro_rules! bytecode {
                                     Ok(()) => {
                                         // SAFETY: `compiled_program` has the same length as
                                         // `vm.bytecode` and `vm.pc()` is always in bounds for that
-                                        let next = unsafe { compiled_program.get_unchecked(pc) };
+                                        let next = unsafe { pc.read() };
                                         (next.function)(vm, pc, sp, offset, compiled_program)
                                     }
                                 }
@@ -136,13 +137,26 @@ impl<'a> CompiledBytecodes<'a> {
         debug_assert!(index <= self.2);
         unsafe { self.0.add(index).read() }
     }
+
+    unsafe fn index(self, pc: NonNull<CompiledBytecode>) -> usize {
+        unsafe { pc.offset_from_unsigned(self.0) }
+    }
+
+    unsafe fn get_pc(&self, index: usize) -> NonNull<CompiledBytecode> {
+        unsafe { self.0.add(index) }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct CompiledBytecode {
     pub(crate) bytecode: Bytecode,
-    pub(crate) function:
-        for<'a> fn(&mut Vm<'a, '_>, usize, NonNull<nanboxed::Value<'a>>, u32, CompiledBytecodes),
+    pub(crate) function: for<'a> fn(
+        &mut Vm<'a, '_>,
+        NonNull<CompiledBytecode>,
+        NonNull<nanboxed::Value<'a>>,
+        u32,
+        CompiledBytecodes,
+    ),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -304,7 +318,18 @@ impl fmt::Display for Bytecode {
 fn validate_bytecode(
     bytecodes: &[Bytecode],
     metadata: &[Metadata],
+    compiled_bytecodes: CompiledBytecodes,
 ) -> Result<(), vm::InvalidBytecode> {
+    #[cfg(debug_assertions)]
+    debug_assert_eq!(bytecodes.len(), compiled_bytecodes.2);
+
+    itertools::assert_equal(
+        bytecodes.iter().copied(),
+        unsafe { std::slice::from_raw_parts(compiled_bytecodes.0.as_ptr(), bytecodes.len()) }
+            .iter()
+            .map(|compiled_bytecode| compiled_bytecode.bytecode),
+    );
+
     let valid_jump_targets = 1..u32::try_from(bytecodes.len()).unwrap();
 
     if !matches!(bytecodes.last(), Some(Bytecode::End)) {

--- a/crabbing-interpreters/src/bytecode.rs
+++ b/crabbing-interpreters/src/bytecode.rs
@@ -69,7 +69,6 @@ macro_rules! bytecode {
                                 mut pc: NonNull<CompiledBytecode>,
                                 mut sp: NonNull<nanboxed::Value<'a>>,
                                 mut offset: u32,
-                                compiled_program: CompiledBytecodes,
                             ) {
                                 let $name::$variant_name $( ( $( $variant_name ${ignore($ty)} ,)* ) )?
                                     // SAFETY: `compiled_program` has the same length as
@@ -85,7 +84,6 @@ macro_rules! bytecode {
                                     &mut pc,
                                     &mut sp,
                                     &mut offset,
-                                    compiled_program,
                                     $name::$variant_name $( ( $( $variant_name ${ignore($ty)} ,)* ) )?,
                                 );
                                 match result {
@@ -99,7 +97,7 @@ macro_rules! bytecode {
                                         // SAFETY: `compiled_program` has the same length as
                                         // `vm.bytecode` and `vm.pc()` is always in bounds for that
                                         let next = unsafe { pc.read() };
-                                        (next.function)(vm, pc, sp, offset, compiled_program)
+                                        (next.function)(vm, pc, sp, offset)
                                     }
                                 }
                             }
@@ -150,13 +148,8 @@ impl<'a> CompiledBytecodes<'a> {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct CompiledBytecode {
     pub(crate) bytecode: Bytecode,
-    pub(crate) function: for<'a> fn(
-        &mut Vm<'a, '_>,
-        NonNull<CompiledBytecode>,
-        NonNull<nanboxed::Value<'a>>,
-        u32,
-        CompiledBytecodes,
-    ),
+    pub(crate) function:
+        for<'a> fn(&mut Vm<'a, '_>, NonNull<CompiledBytecode>, NonNull<nanboxed::Value<'a>>, u32),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/crabbing-interpreters/src/bytecode/vm.rs
+++ b/crabbing-interpreters/src/bytecode/vm.rs
@@ -118,6 +118,7 @@ struct CachedMethod<'a> {
 
 pub(crate) struct Vm<'a, 'b> {
     compiled_bytecodes: CompiledBytecodes<'b>,
+    inline_cache: Box<[Option<CachedMethod<'a>>]>,
     constants: &'b [nanboxed::Value<'a>],
     metadata: &'b [Metadata<'a>],
     error_locations: &'b [ContainingExpression<'a>],
@@ -128,7 +129,6 @@ pub(crate) struct Vm<'a, 'b> {
     cell_vars: Cells<'a>,
     execution_counts: Box<[u64; Bytecode::all_discriminants().len()]>,
     error: Option<Box<Error<'a>>>,
-    inline_cache: Box<[Option<CachedMethod<'a>>]>,
 }
 
 impl Drop for Vm<'_, '_> {

--- a/crabbing-interpreters/src/lib.rs
+++ b/crabbing-interpreters/src/lib.rs
@@ -439,6 +439,7 @@ pub fn run<'a>(
                         &error_locations,
                         stack,
                         global_cells,
+                        compiled_bytecodes,
                     )?)?,
                     Loop::Threaded => {
                         let mut vm = Vm::new(
@@ -448,8 +449,9 @@ pub fn run<'a>(
                             &error_locations,
                             stack,
                             global_cells,
+                            compiled_bytecodes,
                         )?;
-                        vm.run_threaded(compiled_bytecodes);
+                        vm.run_threaded();
 
                         if args.show_bytecode_execution_counts {
                             let max_len = Bytecode::all_discriminants()


### PR DESCRIPTION
This avoids a `lea` per instruction.