### PR TITLE
Improve `perf` profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,5 +40,3 @@ opt-level = "z"
 [profile.perf]
 inherits = "release"
 debug = 2
-lto = true
-codegen-units = 1


### PR DESCRIPTION
The default options for the `release` profile seem to lead to better code, so only set `debug = 2` for more accurate `perf` profiles.

Somehow this improves performance in the `trees` benchmark by ~25%. Some other benchmarks are improved by smaller amounts and some benchmarks don’t show any performance impact.