### PR TITLE
vm: Fix bytecode for `return` in `if` block with `else`

### DIFF
--- a/crabbing-interpreters/src/bytecode.rs
+++ b/crabbing-interpreters/src/bytecode.rs
@@ -222,8 +222,6 @@ bytecode! {
         StoreGlobalByName(InternedString),
         JumpIfTrue(u32),
         JumpIfFalse(u32),
-        PopJumpIfTrue(u32),
-        PopJumpIfFalse(u32),
         Jump(u32),
         BeginFunction(u32),
         Return,
@@ -290,8 +288,6 @@ impl fmt::Display for Bytecode {
             StoreGlobalByName(string) => write!(f, "store_global_by_name {string}"),
             JumpIfTrue(target) => write!(f, "jump_if_true {target}"),
             JumpIfFalse(target) => write!(f, "jump_if_false {target}"),
-            PopJumpIfTrue(target) => write!(f, "pop_jump_if_true {target}"),
-            PopJumpIfFalse(target) => write!(f, "pop_jump_if_false {target}"),
             Jump(target) => write!(f, "jump {target}"),
             BeginFunction(size) => write!(f, "function {size}"),
             Return => write!(f, "return"),
@@ -333,8 +329,6 @@ fn validate_bytecode(
         match bytecode {
             Bytecode::JumpIfTrue(target)
             | Bytecode::JumpIfFalse(target)
-            | Bytecode::PopJumpIfTrue(target)
-            | Bytecode::PopJumpIfFalse(target)
             | Bytecode::Jump(target)
             | Bytecode::BeginFunction(target) =>
                 if !valid_jump_targets.contains(&target) {

--- a/crabbing-interpreters/src/bytecode/compiler.rs
+++ b/crabbing-interpreters/src/bytecode/compiler.rs
@@ -162,11 +162,11 @@ impl<'a> Compiler<'a> {
                 self.code[jump_index] = match or_else {
                     Some(or_else) => {
                         let jump_index = self.code.len();
-                        self.code.push(PopJumpIfTrue(0));
+                        self.code.push(End);
                         let jump_target = self.code.len();
                         self.compile_stmt(or_else);
-                        self.code[jump_index] = PopJumpIfTrue(self.code.len().try_into().unwrap());
-                        PopJumpIfFalse(jump_target.try_into().unwrap())
+                        self.code[jump_index] = Jump(self.code.len().try_into().unwrap());
+                        JumpIfFalse(jump_target.try_into().unwrap())
                     }
                     None => JumpIfFalse(self.code.len().try_into().unwrap()),
                 };

--- a/crabbing-interpreters/src/bytecode/vm.rs
+++ b/crabbing-interpreters/src/bytecode/vm.rs
@@ -583,20 +583,6 @@ pub(crate) fn execute_bytecode<'a>(
                 *pc = unsafe { vm.get_pc(target.cast() - 1) };
             }
         }
-        PopJumpIfTrue(target) => {
-            let value = vm.stack(*sp).peek();
-            if value.is_truthy() {
-                vm.stack_mut(sp).pop();
-                *pc = unsafe { vm.get_pc(target.cast() - 1) };
-            }
-        }
-        PopJumpIfFalse(target) => {
-            let value = vm.stack(*sp).peek();
-            if !value.is_truthy() {
-                vm.stack_mut(sp).pop();
-                *pc = unsafe { vm.get_pc(target.cast() - 1) };
-            }
-        }
         Jump(target) => {
             *pc = unsafe { vm.get_pc(target.cast() - 1) };
         }

--- a/crabbing-interpreters/tests/cases/return_in_if_else.lox
+++ b/crabbing-interpreters/tests/cases/return_in_if_else.lox
@@ -1,0 +1,10 @@
+fun f() {
+    if (true) {
+        return 42;
+    }
+    else {
+        print "not executed";
+    }
+}
+
+print f();

--- a/crabbing-interpreters/tests/testsuite/snapshots/testsuite__crabbing-interpreters__tests__cases__return_in_if_else.lox.snap
+++ b/crabbing-interpreters/tests/testsuite/snapshots/testsuite__crabbing-interpreters__tests__cases__return_in_if_else.lox.snap
@@ -1,0 +1,14 @@
+---
+source: crabbing-interpreters/tests/testsuite/main.rs
+info:
+  program: crabbing-interpreters
+  args:
+    - "--loop=threaded"
+    - crabbing-interpreters/tests/cases/return_in_if_else.lox
+---
+success: true
+exit_code: 0
+----- stdout -----
+42
+
+----- stderr -----

--- a/crabbing-interpreters/tests/testsuite/snapshots/testsuite__scope-crabbing-interpreters__tests__cases__return_in_if_else.lox.snap
+++ b/crabbing-interpreters/tests/testsuite/snapshots/testsuite__scope-crabbing-interpreters__tests__cases__return_in_if_else.lox.snap
@@ -1,0 +1,25 @@
+---
+source: crabbing-interpreters/tests/testsuite/main.rs
+info:
+  program: crabbing-interpreters
+  args:
+    - "--loop=ast"
+    - crabbing-interpreters/tests/cases/return_in_if_else.lox
+    - "--scopes"
+    - "--stop-at=scopes"
+---
+success: true
+exit_code: 0
+----- stdout -----
+(program
+   (fun f (global @1) [] []
+      (block
+         (if
+            true
+            (block
+               (return 42.0))
+            (block
+               (print "not executed")))))
+   (print (call +2 (global f @1))))
+
+----- stderr -----

--- a/crabbing-interpreters/tests/testsuite/snapshots/testsuite__that_threaded_interpreter_is_properly_tailrecursive.snap
+++ b/crabbing-interpreters/tests/testsuite/snapshots/testsuite__that_threaded_interpreter_is_properly_tailrecursive.snap
@@ -52,21 +52,19 @@ Bytecode execution counts
      GlobalByName (31):      1000000
 StoreGlobalByName (32):      1000000
        JumpIfTrue (33):      3000002
-      JumpIfFalse (34):      2000000
-    PopJumpIfTrue (35):      1000000
-   PopJumpIfFalse (36):      2000000
-             Jump (37):      1000002
-    BeginFunction (38):      3000005
-           Return (39):      9000000
-    BuildFunction (40):      3000005
-              End (41):            1
-             Pop2 (42):      9000000
-            Pop23 (43):      4000000
-       BuildClass (44):      2000002
-            Super (45):      1000000
-     SuperForCall (46):      1000000
-         ConstNil (47):     10000000
-        ConstTrue (48):      2000000
-       ConstFalse (49):      3000000
-      ConstNumber (50):   1061000005
+      JumpIfFalse (34):      4000000
+             Jump (35):      2000002
+    BeginFunction (36):      3000005
+           Return (37):      9000000
+    BuildFunction (38):      3000005
+              End (39):            1
+             Pop2 (40):      9000000
+            Pop23 (41):      4000000
+       BuildClass (42):      2000002
+            Super (43):      1000000
+     SuperForCall (44):      1000000
+         ConstNil (45):     10000000
+        ConstTrue (46):      2000000
+       ConstFalse (47):      3000000
+      ConstNumber (48):   1061000005
             Total     :   2281000034


### PR DESCRIPTION
The previous bytecode would not remove the condition from the stack when leaving the `if` block with a `return`.