### PR TITLE
vm: Fix bytecode for conditional `Return` as last instruction in a function

### DIFF
--- a/crabbing-interpreters/src/bytecode/compiler.rs
+++ b/crabbing-interpreters/src/bytecode/compiler.rs
@@ -423,7 +423,10 @@ impl<'a> Compiler<'a> {
             self.compile_stmt(stmt);
         }
 
-        if self.code.last() != Some(&Return) {
+        if !matches!(
+            function.body.last(),
+            Some(Statement::Return(_) | Statement::InitReturn(_)),
+        ) {
             self.code.push(ConstNil);
             self.code.push(Return);
         }

--- a/crabbing-interpreters/tests/cases/conditional_return_at_end_of_function.lox
+++ b/crabbing-interpreters/tests/cases/conditional_return_at_end_of_function.lox
@@ -1,0 +1,23 @@
+fun f() {
+    if (true) {
+        print 42;
+    }
+    else {
+        return 27;
+    }
+}
+
+print f();
+
+class C {
+    init() {
+        if (true) {
+            print 42;
+        }
+        else {
+            return;
+        }
+    }
+}
+
+print C();

--- a/crabbing-interpreters/tests/testsuite/snapshots/testsuite__crabbing-interpreters__tests__cases__conditional_return_at_end_of_function.lox.snap
+++ b/crabbing-interpreters/tests/testsuite/snapshots/testsuite__crabbing-interpreters__tests__cases__conditional_return_at_end_of_function.lox.snap
@@ -1,0 +1,17 @@
+---
+source: crabbing-interpreters/tests/testsuite/main.rs
+info:
+  program: crabbing-interpreters
+  args:
+    - "--loop=threaded"
+    - crabbing-interpreters/tests/cases/conditional_return_at_end_of_function.lox
+---
+success: true
+exit_code: 0
+----- stdout -----
+42
+nil
+42
+<C instance at [POINTER]>
+
+----- stderr -----

--- a/crabbing-interpreters/tests/testsuite/snapshots/testsuite__scope-crabbing-interpreters__tests__cases__conditional_return_at_end_of_function.lox.snap
+++ b/crabbing-interpreters/tests/testsuite/snapshots/testsuite__scope-crabbing-interpreters__tests__cases__conditional_return_at_end_of_function.lox.snap
@@ -1,0 +1,36 @@
+---
+source: crabbing-interpreters/tests/testsuite/main.rs
+info:
+  program: crabbing-interpreters
+  args:
+    - "--loop=ast"
+    - crabbing-interpreters/tests/cases/conditional_return_at_end_of_function.lox
+    - "--scopes"
+    - "--stop-at=scopes"
+---
+success: true
+exit_code: 0
+----- stdout -----
+(program
+   (fun f (global @1) [] []
+      (block
+         (if
+            true
+            (block
+               (print 42.0))
+            (block
+               (return 27.0)))))
+   (print (call +2 (global f @1)))
+   (class C (global @2) ∅
+      (method init [(local this @0)] []
+         (block
+            (if
+               true
+               (block
+                  (print 42.0))
+               (block
+                  (init-return)))
+            (init-return))))
+   (print (call +3 (global C @2))))
+
+----- stderr -----


### PR DESCRIPTION
The previous check did not take into account that the `Return` instruction at the end of `self.code` could have been jumped over, which would fall through to whatever code would be next after the function.