### PR TITLE
Use `rust–preserve-none` calling convention for threaded interpreter loop

### DIFF
--- a/crabbing-interpreters/src/bytecode.rs
+++ b/crabbing-interpreters/src/bytecode.rs
@@ -63,6 +63,7 @@ macro_rules! bytecode {
                     $(
                         $name::$variant_name $( ( $(_ ${ignore($ty)} ,)* ) )? => {
                             #[allow(non_snake_case)]
+                            extern "rust-preserve-none"
                             fn $variant_name<'a>(
                                 vm: &mut Vm<'a, '_>,
                                 mut pc: NonNull<CompiledBytecode>,
@@ -152,8 +153,12 @@ impl<'a> CompiledBytecodes<'a> {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct CompiledBytecode {
     pub(crate) bytecode: Bytecode,
-    pub(crate) function:
-        for<'a> fn(&mut Vm<'a, '_>, NonNull<CompiledBytecode>, NonNull<nanboxed::Value<'a>>, u32),
+    pub(crate) function: for<'a> extern "rust-preserve-none" fn(
+        &mut Vm<'a, '_>,
+        NonNull<CompiledBytecode>,
+        NonNull<nanboxed::Value<'a>>,
+        u32,
+    ),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/crabbing-interpreters/src/lib.rs
+++ b/crabbing-interpreters/src/lib.rs
@@ -11,6 +11,7 @@
 #![feature(never_type)]
 #![feature(ptr_metadata)]
 #![feature(rust_cold_cc)]
+#![feature(rust_preserve_none_cc)]
 #![feature(slice_from_ptr_range)]
 #![feature(slice_ptr_get)]
 #![feature(stmt_expr_attributes)]


### PR DESCRIPTION
Just this change improves performance by up to 15%, with most improvements being about ~8% and some benchmarks (e. g. `fib` and `instantiation`) unaffected.