### PR TITLE
Tail call `set_error`

### DIFF
--- a/crabbing-interpreters/src/bytecode.rs
+++ b/crabbing-interpreters/src/bytecode.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::mem::ManuallyDrop;
 use std::ptr::NonNull;
 
 use crate::bytecode::compiler::Metadata;
@@ -63,12 +64,12 @@ macro_rules! bytecode {
                     $(
                         $name::$variant_name $( ( $(_ ${ignore($ty)} ,)* ) )? => {
                             #[allow(non_snake_case)]
-                            extern "tail"
+                            extern "rust-preserve-none"
                             fn $variant_name<'a>(
                                 vm: &mut Vm<'a, '_>,
                                 mut pc: NonNull<CompiledBytecode>,
                                 mut sp: NonNull<nanboxed::Value<'a>>,
-                                mut offset: u32,
+                                mut offset: OffsetOrError<'a>,
                             ) {
                                 let $name::$variant_name $( ( $( $variant_name ${ignore($ty)} ,)* ) )?
                                     // SAFETY: `compiled_program` has the same length as
@@ -83,24 +84,27 @@ macro_rules! bytecode {
                                     vm,
                                     &mut pc,
                                     &mut sp,
-                                    &mut offset,
+                                    unsafe { &mut offset.offset },
                                     $name::$variant_name $( ( $( $variant_name ${ignore($ty)} ,)* ) )?,
                                 );
                                 match result {
                                     Err(error) => {
                                         #[cold]
                                         #[inline(never)]
-                                        extern "tail" fn set_error<'a>(
+                                        extern "rust-preserve-none" fn set_error<'a>(
                                             vm: &mut Vm<'a, '_>,
+                                            _pc: NonNull<CompiledBytecode>,
                                             sp: NonNull<nanboxed::Value<'a>>,
-                                            error: Option<Box<crate::eval::Error<'a>>>,
+                                            error: OffsetOrError<'a>,
                                         ) {
                                             unsafe {
                                                 vm.set_stack_pointer(sp);
                                             }
-                                            vm.set_error(error)
+                                            let error = unsafe { error.error };
+                                            vm.set_error(ManuallyDrop::into_inner(error))
                                         }
-                                        become set_error(vm, sp, error);
+                                        let error = ManuallyDrop::new(error);
+                                        become set_error(vm, NonNull::dangling(), sp, OffsetOrError { error });
                                     }
                                     Ok(()) => {
                                         // SAFETY: `compiled_program` has the same length as
@@ -150,14 +154,19 @@ impl<'a> CompiledBytecodes<'a> {
     }
 }
 
+pub(crate) union OffsetOrError<'a> {
+    offset: u32,
+    error: ManuallyDrop<Option<Box<crate::eval::Error<'a>>>>,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct CompiledBytecode {
     pub(crate) bytecode: Bytecode,
-    pub(crate) function: for<'a> extern "tail" fn(
+    pub(crate) function: for<'a> extern "rust-preserve-none" fn(
         &mut Vm<'a, '_>,
         NonNull<CompiledBytecode>,
         NonNull<nanboxed::Value<'a>>,
-        u32,
+        OffsetOrError<'a>,
     ),
 }
 

--- a/crabbing-interpreters/src/bytecode.rs
+++ b/crabbing-interpreters/src/bytecode.rs
@@ -90,7 +90,7 @@ macro_rules! bytecode {
                                     Err(error) => {
                                         #[cold]
                                         #[inline(never)]
-                                        fn set_error<'a>(
+                                        extern "tail" fn set_error<'a>(
                                             vm: &mut Vm<'a, '_>,
                                             sp: NonNull<nanboxed::Value<'a>>,
                                             error: Option<Box<crate::eval::Error<'a>>>,
@@ -100,7 +100,7 @@ macro_rules! bytecode {
                                             }
                                             vm.set_error(error)
                                         }
-                                        set_error(vm, sp, error);
+                                        become set_error(vm, sp, error);
                                     }
                                     Ok(()) => {
                                         // SAFETY: `compiled_program` has the same length as

--- a/crabbing-interpreters/src/bytecode.rs
+++ b/crabbing-interpreters/src/bytecode.rs
@@ -63,7 +63,7 @@ macro_rules! bytecode {
                     $(
                         $name::$variant_name $( ( $(_ ${ignore($ty)} ,)* ) )? => {
                             #[allow(non_snake_case)]
-                            extern "rust-preserve-none"
+                            extern "tail"
                             fn $variant_name<'a>(
                                 vm: &mut Vm<'a, '_>,
                                 mut pc: NonNull<CompiledBytecode>,
@@ -153,7 +153,7 @@ impl<'a> CompiledBytecodes<'a> {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct CompiledBytecode {
     pub(crate) bytecode: Bytecode,
-    pub(crate) function: for<'a> extern "rust-preserve-none" fn(
+    pub(crate) function: for<'a> extern "tail" fn(
         &mut Vm<'a, '_>,
         NonNull<CompiledBytecode>,
         NonNull<nanboxed::Value<'a>>,

--- a/crabbing-interpreters/src/bytecode/vm.rs
+++ b/crabbing-interpreters/src/bytecode/vm.rs
@@ -10,6 +10,7 @@ use super::CompiledBytecodes;
 use crate::Report;
 use crate::bytecode::Bytecode;
 use crate::bytecode::CallInner;
+use crate::bytecode::OffsetOrError;
 use crate::bytecode::compiler::ContainingExpression;
 use crate::bytecode::compiler::Metadata;
 use crate::bytecode::validate_bytecode;
@@ -287,7 +288,8 @@ impl<'a, 'b> Vm<'a, 'b> {
 
     pub(crate) fn run_threaded(&mut self) {
         let compiled_bytecode = unsafe { self.compiled_bytecodes.get_unchecked(0) };
-        (compiled_bytecode.function)(self, unsafe { self.get_pc(0) }, self.stack_pointer, 0);
+        let offset = OffsetOrError { offset: 0 };
+        (compiled_bytecode.function)(self, unsafe { self.get_pc(0) }, self.stack_pointer, offset);
     }
 }
 

--- a/crabbing-interpreters/src/lib.rs
+++ b/crabbing-interpreters/src/lib.rs
@@ -11,7 +11,7 @@
 #![feature(never_type)]
 #![feature(ptr_metadata)]
 #![feature(rust_cold_cc)]
-#![feature(rust_tail_cc)]
+#![feature(rust_preserve_none_cc)]
 #![feature(slice_ptr_get)]
 #![feature(stmt_expr_attributes)]
 #![warn(clippy::as_conversions)]

--- a/crabbing-interpreters/src/lib.rs
+++ b/crabbing-interpreters/src/lib.rs
@@ -11,7 +11,7 @@
 #![feature(never_type)]
 #![feature(ptr_metadata)]
 #![feature(rust_cold_cc)]
-#![feature(rust_preserve_none_cc)]
+#![feature(rust_tail_cc)]
 #![feature(slice_ptr_get)]
 #![feature(stmt_expr_attributes)]
 #![warn(clippy::as_conversions)]


### PR DESCRIPTION
The `tail` calling convention seems to be either slower or unchanged compared to `rust-preserve-none`. Tail calling `set_error` seems to (a) increase instruction count and (b) improve IPC, so overall it’s either the same or slightly faster.